### PR TITLE
DnD трейт на рандомный урон

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -148,6 +148,7 @@
 #define TRAIT_FAST_EQUIP          "fast_equip"
 #define TRAIT_NO_CLONE            "no_clone"
 #define TRAIT_VACCINATED          "vaccinated"
+#define TRAIT_RANDOM_DAMAGE       "random_damage"
 
 /*
  * Used for movables that need to be updated, via COMSIG_ENTER_AREA and COMSIG_EXIT_AREA, when transitioning areas.

--- a/code/datums/qualities/negativeish.dm
+++ b/code/datums/qualities/negativeish.dm
@@ -187,3 +187,11 @@ var/global/list/allergen_reagents_list
 
 /datum/quality/dumb/add_effect(mob/living/carbon/human/H, latespawn)
 	H.adjustBrainLoss(rand(30, 99))
+
+
+/datum/quality/dnd
+	desc = "Вы непредсказуемы, даже для самого себя."
+	requirement = "Кадет, Офицер, Варден, ГСБ."
+
+/datum/quality/dnd/add_effect(mob/living/carbon/human/H, latespawn)
+	ADD_TRAIT(H, TRAIT_RANDOM_DAMAGE, QUALITY_TRAIT)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -10,7 +10,7 @@
 	var/charges = 10
 	var/status = 0
 	var/mob/foundmob = "" //Used in throwing proc.
-	var/agony = 60
+	var/agony
 
 	sweep_step = 2
 
@@ -87,11 +87,13 @@
 		//H.apply_effect(10, STUN, 0)
 		//H.apply_effect(10, WEAKEN, 0)
 		//H.apply_effect(10, STUTTER, 0)
-		if(HAS_TRAIT(src, TRAIT_RANDOM_DAMAGE))
-			var/dice = "10d6"
-			var/r = roll(dice)
-			H.apply_effect(r,AGONY,0)
+		if(HAS_TRAIT(usr, TRAIT_RANDOM_DAMAGE))
+			var/a_dice = "3d20"
+			var/r_agony = roll(a_dice)
+			agony = r_agony
+			H.apply_effect(agony,AGONY,0)
 		else
+			agony = 60
 			H.apply_effect(agony,AGONY,0)
 		H.set_lastattacker_info(user)
 		if(isrobot(src.loc))

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -87,7 +87,12 @@
 		//H.apply_effect(10, STUN, 0)
 		//H.apply_effect(10, WEAKEN, 0)
 		//H.apply_effect(10, STUTTER, 0)
-		H.apply_effect(agony,AGONY,0)
+		if(HAS_TRAIT(src, TRAIT_RANDOM_DAMAGE))
+			var/dice = "10d6"
+			var/r = roll(dice)
+			H.apply_effect(r,AGONY,0)
+		else
+			H.apply_effect(agony,AGONY,0)
 		H.set_lastattacker_info(user)
 		if(isrobot(src.loc))
 			var/mob/living/silicon/robot/R = src.loc

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -183,34 +183,33 @@
 			if(HAS_TRAIT(firer, TRAIT_RANDOM_DAMAGE))
 				var/d_dice
 				var/a_dice
-				if(damage <= 10)									//damage
+				if(damage <= 10)										//damage
 					d_dice = "1d10"
 				if(damage > 10 && damage < 55)
 					d_dice = "7d8"
 				if(damage >= 55)
 					d_dice = "4d20"
-				if(agony < 25)										//stun
+				if(agony < 25)											//stun
 					a_dice = "4d6"
 				if(agony >= 25 && agony < 60)
 					a_dice = "5d12"
 				if(agony >= 60)
 					a_dice = "4d20"
 				
-				var/n9large = 0
-				var/n6extradip = 0
-				var/n7 = 0
+				var/n_9_large = 0										//randomname for vars
+				var/n_6_extradip = 0
+				var/n_7 = 0
 				var/datum/component/mood/mood = GetComponent(/datum/component/mood)
-				if(TK in firer.mutations)							//how to increase the luck
-					n9large = 10
-				if(mood)
-					if(mood.mood_level >= 8)
-						n6extradip = 5
-				if(firer.reagents.has_reagent("psilocybin"))
-					n7 = 15
-				var/order = (n9large)+(n6extradip)+(n7)				//just randomname for var
-
-				var/r_damage = roll(d_dice+(order))
-				var/r_agony = roll(a_dice+(order))
+				if(TK in firer.mutations)								//3 Science-Based Ways to Attract Good Luck:
+					n_9_large = 10										//1 - THING BIG
+				if(mood)												//2 - TAKE LIFE POSITIVELY
+					if(mood.mood_level >= 8)							//3 - DO SOMETHING THIS WEEK THAT YOU'VE NEVER DONE BEFORE.
+						n_6_extradip = 5								//IF YOU INTERACT WITH THE SAME PEOPLE EVERY DAY,
+				if(firer.reagents.has_reagent("psilocybin"))			//EAT THE SAME FOOD AND DO THE SAME CHORES,
+					n_7 = 15											//TRY TO  DIVERSIFY YOUR LIFE
+				var/twon_9 = roll(d_dice)								//AND CATCH LUCK BY THE TAIL
+				var/r_damage = twon_9+n_9_large+n_6_extradip+n_7
+				var/r_agony = roll(a_dice)
 				damage = r_damage
 				agony = r_agony
 				

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -179,43 +179,37 @@
 				damage = max(1, damage - round(damage * (((distance-6)*3)/100)))
 				miss_modifier = - 100 // so sniper rifle and PTR-rifle projectiles cannot miss
 		if (istype(shot_from,/obj/item/weapon/gun))	//If you aim at someone beforehead, it'll hit more often.
+	
 			if(HAS_TRAIT(firer, TRAIT_RANDOM_DAMAGE))
 				var/d_dice
 				var/a_dice
-				if(damage <= 10)
+				if(damage <= 10)									//damage
 					d_dice = "1d10"
 				if(damage > 10 && damage < 55)
-					d_dice = "5d10"
+					d_dice = "7d8"
 				if(damage >= 55)
 					d_dice = "4d20"
-
-				if(agony < 25)
+				if(agony < 25)										//stun
 					a_dice = "4d6"
 				if(agony >= 25 && agony < 60)
 					a_dice = "5d12"
 				if(agony >= 60)
 					a_dice = "4d20"
 				
-				if(TK in firer.mutations)
-					var/r_damage = roll(d_dice+10)
-					var/r_agony = roll(a_dice+10)
+				if(TK in firer.mutations)							//how to increase the luck
+					2n9 = 10										//2n9 just randomname for var
 					if(firer, MOOD_LEVEL_HAPPY4 to INFINITY)
-						var/r_damage = roll(d_dice+5)
-						var/r_agony = roll(a_dice+5)
-					if(TK in firer.mutations)
-						var/r_damage = roll(d_dice+10)
-						var/r_agony = roll(a_dice+10)
-					if(firer.examine(VOX))
-						var/r_damage = roll(d_dice+10)
-						var/r_agony = roll(a_dice+10)
-					if(psilocybin)
-						var/r_damage = roll(d_dice+15)
-						var/r_agony = roll(a_dice+15)
+						2n9 = 15
+						if(psilocybin in firer.total_volume)
+							2n9 = 30
+					
+					(d_dice+2n9) = d4c								//d4c just randomname for var
+					(a_dice+2n9) = a4c
+					var/r_damage = roll(d4c)
+					var/r_agony = roll(a4c)
 				else
 					var/r_damage = roll(d_dice)
 					var/r_agony = roll(a_dice)
-				var/r_damage = roll(d_dice)
-				var/r_agony = roll(a_dice)
 				damage = r_damage
 				agony = r_agony
 				

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -196,20 +196,21 @@
 				if(agony >= 60)
 					a_dice = "4d20"
 				
-				var/n9large = 0										//just randomname for var
+				var/n9large = 0
 				var/n6extradip = 0
 				var/n7 = 0
+				var/datum/component/mood/mood = GetComponent(/datum/component/mood)
 				if(TK in firer.mutations)							//how to increase the luck
 					n9large = 10
-				if(firer, MOOD_LEVEL_HAPPY4 to INFINITY)
-					n6extradip = 5
+				if(mood)
+					if(mood.mood_level >= 8)
+						n6extradip = 5
 				if(firer.reagents.has_reagent("psilocybin"))
 					n7 = 15
-				var/order = (n9large)+(n6extradip)+(n7)
+				var/order = (n9large)+(n6extradip)+(n7)				//just randomname for var
+
 				var/r_damage = roll(d_dice+(order))
 				var/r_agony = roll(a_dice+(order))
-				damage = r_damage
-				agony = r_agony
 				damage = r_damage
 				agony = r_agony
 				

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -196,6 +196,24 @@
 				if(agony >= 60)
 					a_dice = "4d20"
 				
+				if(TK in firer.mutations)
+					var/r_damage = roll(d_dice+10)
+					var/r_agony = roll(a_dice+10)
+					if(firer, MOOD_LEVEL_HAPPY4 to INFINITY)
+						var/r_damage = roll(d_dice+5)
+						var/r_agony = roll(a_dice+5)
+					if(TK in firer.mutations)
+						var/r_damage = roll(d_dice+10)
+						var/r_agony = roll(a_dice+10)
+					if(firer.examine(VOX))
+						var/r_damage = roll(d_dice+10)
+						var/r_agony = roll(a_dice+10)
+					if(psilocybin)
+						var/r_damage = roll(d_dice+15)
+						var/r_agony = roll(a_dice+15)
+				else
+					var/r_damage = roll(d_dice)
+					var/r_agony = roll(a_dice)
 				var/r_damage = roll(d_dice)
 				var/r_agony = roll(a_dice)
 				damage = r_damage

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -197,14 +197,17 @@
 					a_dice = "4d20"
 				
 				if(TK in firer.mutations)							//how to increase the luck
-					2n9 = 10										//2n9 just randomname for var
+					var/order										// just randomname for var
+					var/d4c
+					var/a4c
+					n9large = (10)
 					if(firer, MOOD_LEVEL_HAPPY4 to INFINITY)
-						2n9 = 15
+						n6extradip = (5)
 						if(psilocybin in firer.total_volume)
-							2n9 = 30
-					
-					(d_dice+2n9) = d4c								//d4c just randomname for var
-					(a_dice+2n9) = a4c
+							n7 = (15)
+					order = (n9large)+(n6extradip)+(n7)
+					(d_dice+(order)) = d4c							//d4c just randomname for var
+					(a_dice+(order)) = a4c
 					var/r_damage = roll(d4c)
 					var/r_agony = roll(a4c)
 				else

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -172,6 +172,23 @@
 		if(!isliving(A))
 			loc = A.loc
 			return 0// nope.avi
+		if(HAS_TRAIT(firer, TRAIT_RANDOM_DAMAGE))
+			var/dice = 0
+			var/sum = roll(dice)
+			if(damage)
+				if(damage < 39)
+					dice = "4d10"
+					damage = sum
+				if(damage > 39)
+					dice = "3d20"
+					damage = sum
+			if(agony)
+				if(agony < 30)
+					dice = "5d4"
+					agony = sum
+				if(agony > 30)
+					dice = "4d20"
+					agony = sum
 		var/distance = get_dist(starting,loc) //More distance = less damage, except for high fire power weapons.
 		var/miss_modifier = 0
 		if(damage && (distance > 7))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -196,23 +196,20 @@
 				if(agony >= 60)
 					a_dice = "4d20"
 				
+				var/n9large = 0										//just randomname for var
+				var/n6extradip = 0
+				var/n7 = 0
 				if(TK in firer.mutations)							//how to increase the luck
-					var/order										// just randomname for var
-					var/d4c
-					var/a4c
-					n9large = (10)
-					if(firer, MOOD_LEVEL_HAPPY4 to INFINITY)
-						n6extradip = (5)
-						if(psilocybin in firer.total_volume)
-							n7 = (15)
-					order = (n9large)+(n6extradip)+(n7)
-					(d_dice+(order)) = d4c							//d4c just randomname for var
-					(a_dice+(order)) = a4c
-					var/r_damage = roll(d4c)
-					var/r_agony = roll(a4c)
-				else
-					var/r_damage = roll(d_dice)
-					var/r_agony = roll(a_dice)
+					n9large = 10
+				if(firer, MOOD_LEVEL_HAPPY4 to INFINITY)
+					n6extradip = 5
+				if(firer.reagents.has_reagent("psilocybin"))
+					n7 = 15
+				var/order = (n9large)+(n6extradip)+(n7)
+				var/r_damage = roll(d_dice+(order))
+				var/r_agony = roll(a_dice+(order))
+				damage = r_damage
+				agony = r_agony
 				damage = r_damage
 				agony = r_agony
 				

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -172,23 +172,6 @@
 		if(!isliving(A))
 			loc = A.loc
 			return 0// nope.avi
-		if(HAS_TRAIT(firer, TRAIT_RANDOM_DAMAGE))
-			var/dice = 0
-			var/sum = roll(dice)
-			if(damage)
-				if(damage < 39)
-					dice = "4d10"
-					damage = sum
-				if(damage > 39)
-					dice = "3d20"
-					damage = sum
-			if(agony)
-				if(agony < 30)
-					dice = "5d4"
-					agony = sum
-				if(agony > 30)
-					dice = "4d20"
-					agony = sum
 		var/distance = get_dist(starting,loc) //More distance = less damage, except for high fire power weapons.
 		var/miss_modifier = 0
 		if(damage && (distance > 7))
@@ -196,6 +179,28 @@
 				damage = max(1, damage - round(damage * (((distance-6)*3)/100)))
 				miss_modifier = - 100 // so sniper rifle and PTR-rifle projectiles cannot miss
 		if (istype(shot_from,/obj/item/weapon/gun))	//If you aim at someone beforehead, it'll hit more often.
+			if(HAS_TRAIT(firer, TRAIT_RANDOM_DAMAGE))
+				var/d_dice
+				var/a_dice
+				if(damage <= 10)
+					d_dice = "1d10"
+				if(damage > 10 && damage < 55)
+					d_dice = "5d10"
+				if(damage >= 55)
+					d_dice = "4d20"
+
+				if(agony < 25)
+					a_dice = "4d6"
+				if(agony >= 25 && agony < 60)
+					a_dice = "5d12"
+				if(agony >= 60)
+					a_dice = "4d20"
+				
+				var/r_damage = roll(d_dice)
+				var/r_agony = roll(a_dice)
+				damage = r_damage
+				agony = r_agony
+				
 			var/obj/item/weapon/gun/daddy = shot_from //Kinda balanced by fact you need like 2 seconds to aim
 			if (daddy.target && (original in daddy.target)) //As opposed to no-delay pew pew
 				miss_modifier -= 60


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
По идее надо офицерскому шмотью вписать rand(1,40) вместо фиксированного урона. Было бы круто добавить условие для "Сверх-Удачи", где выбивается стабильно больше максимума постоянно. Либо какой-то смешной долгой процедурой, либо админвмешательством (может предмет клевер создать?)
## Почему и что этот ПР улучшит
ахахахахах https://lifehacker.ru/how-to-increase-your-luck/
## Авторство

## Чеинжлог
